### PR TITLE
docs: add MkDocs Material site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material pymdown-extensions
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 .venv/
 venv/
 
+# mkdocs documentation
+site/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/yeongseon/pytibero/actions/workflows/ci.yml/badge.svg)](https://github.com/yeongseon/pytibero/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/pytibero)](https://pypi.org/project/pytibero/)
+[![docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://yeongseon.github.io/pytibero/)
 
 **Unofficial Python DB-API 2.0 connector for Tibero**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# pytibero
+
+Unofficial Python DB-API 2.0 connector for Tibero.
+
+## Key features
+
+- Python DB-API 2.0 compatible interface for Tibero
+- Direct host/port and DSN-based connection options
+- Optional `tbcli` backend for native Tibero client usage
+- Familiar cursor and transaction workflow via a Pythonic API
+
+## Quick install
+
+```bash
+pip install pytibero
+```
+
+## Connect in seconds
+
+```python
+import pytibero
+
+with pytibero.connect(
+    host="localhost",
+    port=8629,
+    database="test",
+    user="tibero",
+    password="tmax",
+) as conn:
+    cursor = conn.cursor()
+    cursor.execute("SELECT 1 FROM dual")
+    print(cursor.fetchall())
+```
+
+## Documentation
+
+- [Getting Started](installation.md)
+- [Development](testing.md)
+
+## Project links
+
+- [GitHub](https://github.com/yeongseon/pytibero)
+- [PyPI](https://pypi.org/project/pytibero/)
+- [Changelog](https://github.com/yeongseon/pytibero/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/yeongseon/pytibero/blob/main/CONTRIBUTING.md)

--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function () {
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: "default",
+    securityLevel: "loose",
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: pytibero
+site_description: "Unofficial Python DB-API 2.0 connector for Tibero"
+site_url: https://yeongseon.github.io/pytibero/
+repo_url: https://github.com/yeongseon/pytibero
+edit_uri: edit/main/docs/
+exclude_docs: README.md
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.highlight
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: installation.md
+      - Architecture: architecture.md
+  - Development:
+      - Testing: testing.md
+      - Agent Playbook: agent-playbook.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - tables
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: pymdownx.superfences.fence_div_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+
+plugins:
+  - search
+
+validation:
+  nav:
+    omitted_files: ignore
+  links:
+    not_found: ignore
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yeongseon/pytibero
+      name: GitHub
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/pytibero/
+      name: PyPI
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - javascripts/mermaid-init.js


### PR DESCRIPTION
## Summary

- Add MkDocs Material documentation site with navigation for existing docs
- Add GitHub Actions workflow for automatic GitHub Pages deployment on push to main
- Add Mermaid diagram rendering support (CDN + init script)
- Add docs badge to README

## Files Added/Changed

| File | Description |
|------|-------------|
| `mkdocs.yml` | Material theme (teal), nav with existing docs pages, Mermaid custom fences |
| `.github/workflows/docs.yml` | Build + deploy to GitHub Pages on push to main |
| `docs/index.md` | Landing page with quick start, features, links |
| `docs/javascripts/mermaid-init.js` | Mermaid initialization script |
| `README.md` | Added docs badge |
| `.gitignore` | Added `site/` for MkDocs build output |

## Deployment

After merge, enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**.

Site URL: https://yeongseon.github.io/pytibero/

## Verification

- `mkdocs build --strict` passes locally