### PR TITLE
docs: major documentation expansion with API reference, connection guide, type mapping, and diagrams

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,242 @@
+# API Reference
+
+This reference documents the exported DB-API 2.0 surface in `pytibero`.
+
+## Module-level API (`pytibero`)
+
+### Constants
+
+| Name | Value | Notes |
+|---|---|---|
+| `apilevel` | `"2.0"` | DB-API version marker |
+| `threadsafety` | `1` | Threads may share the module, not connections |
+| `paramstyle` | `"qmark"` | SQL placeholders use `?` |
+
+### `connect(...)`
+
+```python
+connect(
+    host: str = "localhost",
+    port: int = 8629,
+    database: str = "",
+    user: str = "tibero",
+    password: str = "",
+    dsn: str | None = None,
+    driver: str = "Tibero 7 ODBC Driver",
+    backend: str = "pyodbc",
+    tbcli_library: str | None = None,
+    autocommit: bool = False,
+    login_timeout: int | None = None,
+    **kwargs: object,
+) -> Connection
+```
+
+Creates and returns a `Connection`.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `host` | `str` | `"localhost"` | Server host for non-DSN mode |
+| `port` | `int` | `8629` | Server port for non-DSN mode |
+| `database` | `str` | `""` | Optional DB/service name |
+| `user` | `str` | `"tibero"` | Login user |
+| `password` | `str` | `""` | Login password |
+| `dsn` | `str \| None` | `None` | DSN name; overrides driver/host/port path |
+| `driver` | `str` | `"Tibero 7 ODBC Driver"` | ODBC driver name |
+| `backend` | `str` | `"pyodbc"` | `pyodbc` or `tbcli` |
+| `tbcli_library` | `str \| None` | `None` | Path hint for native `tbcli` library |
+| `autocommit` | `bool` | `False` | Native connection autocommit |
+| `login_timeout` | `int \| None` | `None` | Login timeout hint |
+| `**kwargs` | `object` | n/a | Routed to native connect kwargs or ODBC options |
+
+## `Connection` class
+
+`Connection` wraps a native backend connection and manages cursor lifecycle and transaction control.
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `closed` | `bool` | `True` when connection is closed |
+| `autocommit` | `bool` | Reads/sets native autocommit |
+| `native_connection` | `object` | Underlying backend connection object |
+
+### Methods
+
+#### `execute(operation: str, parameters: object = None) -> object`
+Creates a cursor and executes one statement in a single call.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `operation` | `str` | SQL text |
+| `parameters` | `object` | Optional bind values |
+
+#### `cursor() -> object`
+Creates a new cursor bound to the connection.
+
+- Returns `pytibero.cursor.Cursor` for `pyodbc`
+- Returns native `TbcliCursor` for `tbcli`
+
+#### `commit() -> None`
+Commits current transaction.
+
+#### `rollback() -> None`
+Rolls back current transaction.
+
+#### `close() -> None`
+Closes tracked cursors, closes native connection, marks connection closed.
+
+#### `getinfo(code: int) -> object`
+Returns backend metadata from native `getinfo`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | `int` | Driver-specific info selector |
+
+#### `setdecoding(*args, **kwargs) -> object`
+Forwards to native connection method when available.
+
+#### `setencoding(*args, **kwargs) -> object`
+Forwards to native connection method when available.
+
+#### `add_output_converter(*args, **kwargs) -> object`
+Forwards to native connection method when available.
+
+#### `clear_output_converters() -> object`
+Forwards to native connection method when available.
+
+#### `remove_output_converter(*args, **kwargs) -> object`
+Forwards to native connection method when available.
+
+### Context manager behavior
+
+`with Connection(...) as conn:` commits on normal exit, rolls back on exception, then closes.
+
+## `Cursor` class (`pytibero.cursor.Cursor`)
+
+DB-API cursor wrapper used with `pyodbc` backend.
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `connection` | `object` | Owning `Connection` |
+| `description` | `tuple[...] \| None` | Result metadata |
+| `rowcount` | `int` | Rows affected (backend-provided) |
+| `arraysize` | `int` | Default fetch size for `fetchmany` |
+| `rownumber` | `int \| None` | Local cursor position tracker |
+| `lastrowid` | `object \| None` | Native `lastrowid` when available |
+| `native_cursor` | `object` | Underlying native cursor |
+
+### Methods
+
+#### `close() -> None`
+Closes native cursor and detaches from connection tracking.
+
+#### `execute(operation: str, parameters: Sequence[Any] | Mapping[str, Any] | None = None) -> Cursor`
+Executes one statement. Mapping parameters are rejected for `qmark` style.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `operation` | `str` | SQL text with `?` placeholders |
+| `parameters` | `Sequence \| Mapping \| None` | Bind values |
+
+#### `executemany(operation: str, seq_of_parameters: Sequence[Sequence[Any] | Mapping[str, Any]]) -> Cursor`
+Runs repeated execution for a sequence of parameter rows.
+
+#### `fetchone() -> tuple[Any, ...] | None`
+Fetches one row.
+
+#### `fetchmany(size: int | None = None) -> list[tuple[Any, ...]]`
+Fetches up to `size` rows (or `arraysize` when omitted).
+
+#### `fetchall() -> list[tuple[Any, ...]]`
+Fetches all remaining rows.
+
+#### `setinputsizes(sizes: Any) -> None`
+No-op placeholder for DB-API compatibility.
+
+#### `setoutputsize(size: int, column: int | None = None) -> None`
+No-op placeholder for DB-API compatibility.
+
+#### `callproc(procname: str, parameters: Sequence[Any] = ()) -> Sequence[Any]`
+Builds and executes `CALL procname(...)`.
+
+#### `nextset() -> object | None`
+Advances to next result set if backend supports it.
+
+#### `scroll(value: int, mode: str = "relative") -> None`
+Uses native cursor scrolling if available, else raises `NotSupportedError`.
+
+### Iterator and context manager
+
+- Iteration (`for row in cursor`) repeatedly calls `fetchone()`
+- `with cursor:` closes cursor on exit
+
+## Type constructors and type objects
+
+### Constructor functions
+
+| Function | Return type | Notes |
+|---|---|---|
+| `Date(year, month, day)` | `datetime.date` | Date constructor |
+| `Time(hour, minute, second)` | `datetime.time` | Time constructor |
+| `Timestamp(year, month, day, hour, minute, second)` | `datetime.datetime` | Datetime constructor |
+| `DateFromTicks(ticks)` | `datetime.date` | From Unix ticks |
+| `TimeFromTicks(ticks)` | `datetime.time` | From Unix ticks |
+| `TimestampFromTicks(ticks)` | `datetime.datetime` | From Unix ticks |
+| `Binary(value)` | `bytes` | Accepts `bytes`, `bytearray`, or `str` |
+
+### `DBAPIType` objects
+
+| Object | Values set |
+|---|---|
+| `STRING` | `{1, 12, 13}` |
+| `BINARY` | `{2, 14}` |
+| `NUMBER` | `{3, 4, 5, 6, 7}` |
+| `DATETIME` | `{8, 9, 10, 11}` |
+| `ROWID` | `{15}` |
+
+## Relationships
+
+```mermaid
+classDiagram
+    class Connection {
+        +bool closed
+        +bool autocommit
+        +cursor() object
+        +commit() None
+        +rollback() None
+        +close() None
+        +getinfo(code) object
+    }
+
+    class Cursor {
+        +description
+        +rowcount
+        +arraysize
+        +rownumber
+        +execute(operation, parameters)
+        +executemany(operation, seq_of_parameters)
+        +fetchone()
+        +fetchmany(size)
+        +fetchall()
+        +callproc(procname, parameters)
+        +nextset()
+        +scroll(value, mode)
+        +close()
+    }
+
+    class DBAPIType {
+        +name: str
+        +values: frozenset[int]
+        +__eq__(other)
+        +__ne__(other)
+    }
+
+    Connection --> Cursor : creates
+    DBAPIType <.. STRING
+    DBAPIType <.. BINARY
+    DBAPIType <.. NUMBER
+    DBAPIType <.. DATETIME
+    DBAPIType <.. ROWID
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,8 @@
 # Architecture
 
+!!! info "Design target"
+    Keep a stable DB-API surface while allowing backend implementation differences (`pyodbc` vs `tbcli`).
+
 ## Layers
 
 1. Application code calls `pytibero.connect(...)`.
@@ -18,3 +21,44 @@
 - The `tbcli` backend uses Tibero's native client library through `ctypes`.
 - Cursor state tracks `rownumber` locally so DB-API iteration remains consistent.
 - Unit tests use a fake `pyodbc` backend; e2e tests validate the real driver path.
+
+## Runtime architecture map
+
+```mermaid
+flowchart TD
+    A[Application SQL call] --> B[pytibero.Connection]
+    B --> C{backend}
+    C -->|pyodbc| D[pyodbc connection and cursor]
+    C -->|tbcli| E[ctypes tbcli driver]
+    D --> F[Native execution]
+    E --> F
+    F --> G[Result conversion and cursor state]
+    G --> H[Package exception mapping]
+```
+
+## Connection construction sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant P as pytibero.connect
+    participant C as Connection
+    participant Pr as protocol.build_connection_string
+    participant B as Backend
+
+    App->>P: connect(...)
+    P->>C: instantiate Connection
+    C->>C: split kwargs (native/options)
+    C->>C: load backend
+    alt pyodbc
+        C->>Pr: build_connection_string(config)
+        C->>B: pyodbc.connect(conn_str, **kwargs)
+    else tbcli
+        C->>B: tbcli.connect(config)
+    end
+    B-->>C: native connection
+    C-->>App: ready Connection object
+```
+
+!!! tip "Error portability"
+    Application code should catch `pytibero` exceptions instead of backend-specific exception classes.

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -1,0 +1,113 @@
+# Connection Guide
+
+This guide documents connection behavior for both supported backends: `pyodbc` (default) and `tbcli`.
+
+## ConnectionConfig fields
+
+`pytibero.connect(...)` is normalized into `ConnectionConfig`.
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `host` | `str` | `"localhost"` | Tibero host when not using DSN |
+| `port` | `int` | `8629` | Tibero port when not using DSN |
+| `database` | `str` | `""` | Database/service name, emitted as `DB=` when set |
+| `user` | `str` | `"tibero"` | Username, emitted as `UID=` when set |
+| `password` | `str` | `""` | Password, emitted as `PWD=` when set |
+| `dsn` | `str \| None` | `None` | DSN name; when set, driver/host/port path is skipped |
+| `driver` | `str` | `"Tibero 7 ODBC Driver"` | ODBC driver name for non-DSN mode |
+| `backend` | `str` | `"pyodbc"` | Backend selector: `pyodbc` or `tbcli` |
+| `tbcli_library` | `str \| None` | `None` | Optional explicit path to `tbcli` shared library |
+| `autocommit` | `bool` | `False` | Transaction mode applied on native connection |
+| `login_timeout` | `int \| None` | `None` | Login timeout hint |
+| `connect_kwargs` | `dict[str, object]` | `{}` | pyodbc-native kwargs routed to `pyodbc.connect` |
+| `options` | `dict[str, object]` | `{}` | Extra attributes appended into the ODBC connection string |
+
+## Backend selection and connection flow
+
+```mermaid
+flowchart TD
+    A[pytibero.connect(...)] --> B[Connection.__init__]
+    B --> C{backend.lower()}
+    C -->|pyodbc| D[import pyodbc]
+    C -->|tbcli| E[load_tbcli_driver]
+    C -->|other| F[InterfaceError unsupported backend]
+    D --> G[build_connection_string(config)]
+    E --> H[tbcli connect(config)]
+    G --> I[pyodbc.connect(conn_str, **connect_kwargs)]
+    I --> J[Connection ready]
+    H --> J
+```
+
+## DSN mode vs driver mode
+
+### DSN mode (`dsn` provided)
+
+- Connection string starts with `DSN=<dsn>`.
+- `DRIVER`, `SERVER`, and `PORT` are not added.
+- `UID` / `PWD` are still appended when provided.
+
+### Driver mode (`dsn` omitted)
+
+- Connection string includes:
+  - `DRIVER=<driver>`
+  - `SERVER=<host>`
+  - `PORT=<port>`
+  - optional `DB=<database>`
+- Then appends `UID` / `PWD` and option attributes.
+
+## Connection string assembly
+
+`protocol.build_connection_string(config)` builds attributes in this order:
+
+1. DSN or driver/server/port/database segment
+2. Credentials (`UID`, `PWD`) when non-empty
+3. Extra options from `config.options` (skips keys with `None` values)
+
+Value formatting rules:
+
+- Boolean option values become `1` / `0`
+- Values containing `;`, `{`, `}`, spaces, or surrounding whitespace are brace-escaped
+- `DRIVER` is always brace-escaped
+- Final string is `;`-terminated
+
+```mermaid
+flowchart LR
+    A[ConnectionConfig] --> B{dsn set?}
+    B -->|yes| C[Add DSN]
+    B -->|no| D[Add DRIVER SERVER PORT optional DB]
+    C --> E[Add UID and PWD if present]
+    D --> E
+    E --> F[Append options excluding None]
+    F --> G[Escape values and join with semicolons]
+    G --> H[Return connection string with trailing semicolon]
+```
+
+## Connection kwargs routing
+
+Extra keyword arguments are split into two buckets:
+
+### Routed to `pyodbc.connect(..., **kwargs)` as native kwargs
+
+- `ansi`
+- `attrs_before`
+- `encoding`
+- `readonly`
+- `timeout`
+- `unicode_results`
+
+### Routed to ODBC string attributes (`options`)
+
+All other extra kwargs (for example `ApplicationName="my-app"`) are appended to the connection string as key/value attributes.
+
+Additionally:
+
+- `autocommit` is always set explicitly in native connect kwargs for `pyodbc`
+- If `login_timeout` is set and `timeout` was not explicitly supplied, `timeout=login_timeout` is injected
+
+!!! tip "Choosing backend"
+    Start with `pyodbc` for standard ODBC deployments. Use `tbcli` when you want direct native client control or cannot rely on `pyodbc` in your runtime.
+
+!!! warning "Common connection errors"
+    - `InterfaceError: pyodbc is required...` means `pyodbc` is missing in your environment.
+    - `InterfaceError: tbcli library could not be loaded...` means the shared library path/discovery failed.
+    - `InterfaceError: unsupported backend: ...` means `backend` is not `pyodbc` or `tbcli`.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,112 @@
+# Error Handling
+
+`pytibero` provides package-owned PEP 249-compatible exceptions so application code can handle errors consistently across backends.
+
+## Exception hierarchy
+
+```mermaid
+flowchart TD
+    EX[Exception]
+    EX --> W[Warning]
+    EX --> E[Error]
+    E --> IE[InterfaceError]
+    E --> DE[DatabaseError]
+    DE --> DAE[DataError]
+    DE --> OE[OperationalError]
+    DE --> INE[IntegrityError]
+    DE --> ITE[InternalError]
+    DE --> PE[ProgrammingError]
+    DE --> NSE[NotSupportedError]
+```
+
+## Exception classes
+
+| Class | Base | Typical usage |
+|---|---|---|
+| `Warning` | `Exception` | Important non-fatal warnings |
+| `Error` | `Exception` | Root package error type |
+| `InterfaceError` | `Error` | Client-side interface/configuration misuse |
+| `DatabaseError` | `Error` | Database/backend failures with optional `errno` / `sqlstate` |
+| `DataError` | `DatabaseError` | Data conversion or processed-data issues |
+| `OperationalError` | `DatabaseError` | Runtime operational failures (connectivity, transport) |
+| `IntegrityError` | `DatabaseError` | Constraint/integrity violations |
+| `InternalError` | `DatabaseError` | Database internal error conditions |
+| `ProgrammingError` | `DatabaseError` | Invalid SQL or DB-API usage |
+| `NotSupportedError` | `DatabaseError` | Unsupported API feature or backend operation |
+
+## Backend error mapping
+
+### `pyodbc` backend
+
+Native `pyodbc` exceptions are mapped to local exceptions by class name:
+
+- `pyodbc.InterfaceError` -> `pytibero.InterfaceError`
+- `pyodbc.DataError` -> `pytibero.DataError`
+- `pyodbc.IntegrityError` -> `pytibero.IntegrityError`
+- `pyodbc.InternalError` -> `pytibero.InternalError`
+- `pyodbc.ProgrammingError` -> `pytibero.ProgrammingError`
+- `pyodbc.NotSupportedError` -> `pytibero.NotSupportedError`
+- `pyodbc.OperationalError` -> `pytibero.OperationalError`
+- `pyodbc.DatabaseError` -> `pytibero.DatabaseError`
+- `pyodbc.Error` -> `pytibero.Error`
+
+`sqlstate` (5-char string) and native error numbers are extracted when available and attached to mapped exceptions.
+
+### `tbcli` backend
+
+The `tbcli` transport raises package exceptions directly (for example `OperationalError`, `ProgrammingError`, `DataError`, `InterfaceError`) based on return codes and conversion paths.
+
+!!! tip "Always catch package exceptions"
+    Catch `pytibero.Error` (or subclasses) rather than backend-specific exception classes to keep code portable between `pyodbc` and `tbcli`.
+
+## Recommended patterns
+
+### Generic DB-API error boundary
+
+```python
+import pytibero
+
+try:
+    with pytibero.connect(host="localhost", user="tibero", password="tmax") as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM dual")
+            print(cur.fetchall())
+except pytibero.Error as exc:
+    print(f"Database operation failed: {exc}")
+```
+
+### Handle specific categories
+
+```python
+import pytibero
+
+try:
+    conn = pytibero.connect(backend="tbcli", tbcli_library="/bad/path/libtbcli.so")
+except pytibero.InterfaceError as exc:
+    # Missing backend dependency, bad backend name, closed-connection access, etc.
+    print(f"Configuration/interface issue: {exc}")
+except pytibero.OperationalError as exc:
+    # Network, connection establishment, runtime operational errors
+    print(f"Operational failure: {exc}")
+except pytibero.DatabaseError as exc:
+    # Broad DB-side category, includes errno/sqlstate when available
+    print(f"Database error: {exc}; errno={exc.errno}; sqlstate={exc.sqlstate}")
+```
+
+### Transaction-safe pattern
+
+```python
+import pytibero
+
+conn = pytibero.connect(host="localhost", user="tibero", password="tmax")
+try:
+    cur = conn.cursor()
+    cur.execute("UPDATE accounts SET balance = balance - ? WHERE id = ?", (10, 1))
+    cur.execute("UPDATE accounts SET balance = balance + ? WHERE id = ?", (10, 2))
+    conn.commit()
+except pytibero.DatabaseError:
+    conn.rollback()
+    raise
+finally:
+    conn.close()
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,82 @@
+# FAQ
+
+## Troubleshooting decision tree
+
+```mermaid
+flowchart TD
+    A[Connection or runtime issue] --> B{Using backend?}
+    B -->|pyodbc| C{pyodbc import works?}
+    C -->|no| C1[Install pyodbc and system ODBC manager]
+    C -->|yes| D{Tibero ODBC driver registered?}
+    D -->|no| D1[Install/register Tibero ODBC driver]
+    D -->|yes| E[Check DSN/host/port/credentials]
+    B -->|tbcli| F{tbcli library loadable?}
+    F -->|no| F1[Set tbcli_library or library path]
+    F -->|yes| E
+    E --> G{Still failing?}
+    G -->|yes| H[Check server status, firewall, encoding/NLS]
+    G -->|no| I[Resolved]
+```
+
+??? question "pyodbc not found"
+    **Symptom**
+    - `InterfaceError: pyodbc is required to use pytibero...`
+
+    **Fix**
+    1. Install Python package:
+       ```bash
+       pip install pyodbc
+       ```
+    2. Ensure system ODBC manager is installed (for example unixODBC on Linux).
+    3. Verify import in the target runtime environment:
+       ```bash
+       python -c "import pyodbc; print(pyodbc.version)"
+       ```
+
+??? question "Tibero ODBC driver not found"
+    **Symptom**
+    - Connection fails with driver/DSN resolution errors.
+
+    **Fix**
+    1. Install the Tibero ODBC driver package.
+    2. Verify ODBC driver registration (commonly in `odbcinst.ini`).
+    3. If using DSN mode, confirm DSN entry exists and points to the correct driver/server.
+    4. If using driver mode, ensure `driver="Tibero 7 ODBC Driver"` matches installed driver name.
+
+??? question "tbcli library not found"
+    **Symptom**
+    - `InterfaceError: tbcli library could not be loaded...`
+
+    **Fix**
+    1. Provide explicit `tbcli_library` path:
+       ```python
+       conn = pytibero.connect(backend="tbcli", tbcli_library="/opt/tibero7/client/lib/libtbcli.so")
+       ```
+    2. Or configure dynamic library search path (`LD_LIBRARY_PATH` on Linux).
+    3. Confirm file permissions and architecture compatibility.
+
+??? question "Connection refused or timeout"
+    **Symptom**
+    - Operational errors during connect.
+
+    **Fix checklist**
+    - Verify Tibero server process is running.
+    - Confirm host and port (`8629` by default).
+    - Check firewall/security group rules.
+    - Validate credentials and database/service name.
+    - Try `login_timeout` to fail faster and identify connectivity issues early.
+
+??? question "Character encoding issues"
+    **Symptom**
+    - Garbled text, replacement characters, or decoding mismatches.
+
+    **Fix**
+    1. Align Tibero NLS/character-set settings between server and client environment.
+    2. For `pyodbc`, consider explicit connect kwargs like `encoding` / `unicode_results`.
+    3. Verify application assumes UTF-8 where appropriate.
+    4. Test round-trip insert/select for multilingual strings.
+
+## Additional checks
+
+- Use [Connection Guide](connection.md) to verify kwargs routing and DSN/driver behavior.
+- Use [Error Handling](errors.md) to classify exceptions and recover safely.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,32 @@
 
 Unofficial Python DB-API 2.0 connector for Tibero.
 
+!!! info "What pytibero provides"
+    `pytibero` exposes a DB-API 2.0-compliant interface while supporting two runtime backends:
+    `pyodbc` (default) and native `tbcli`.
+
+!!! tip "Portable application code"
+    Write against `pytibero` exception classes and DB-API patterns so your code remains backend-agnostic.
+
 ## Key features
 
 - Python DB-API 2.0 compatible interface for Tibero
 - Direct host/port and DSN-based connection options
 - Optional `tbcli` backend for native Tibero client usage
 - Familiar cursor and transaction workflow via a Pythonic API
+
+## Feature overview
+
+```mermaid
+flowchart LR
+    A[Application code] --> B[pytibero.connect]
+    B --> C{Backend}
+    C -->|pyodbc| D[ODBC driver path]
+    C -->|tbcli| E[Native tbcli path]
+    D --> F[Connection and Cursor API]
+    E --> F
+    F --> G[DB-API exceptions and type helpers]
+```
 
 ## Quick install
 
@@ -35,6 +55,12 @@ with pytibero.connect(
 ## Documentation
 
 - [Getting Started](installation.md)
+- [Quick Start](quickstart.md)
+- [Connection Guide](connection.md)
+- [API Reference](api.md)
+- [Type Mapping](types.md)
+- [Error Handling](errors.md)
+- [FAQ](faq.md)
 - [Development](testing.md)
 
 ## Project links

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,9 @@
 # Installation
 
+!!! note "Backend choice"
+    `pyodbc` is the default backend and works well in standard ODBC deployments.
+    Use `tbcli` when you need direct native Tibero client connectivity.
+
 ## Python package
 
 ```bash
@@ -20,6 +24,22 @@ pip install -e ".[dev]"
 - unixODBC or another compatible ODBC manager
 - `pyodbc`
 - A Tibero ODBC driver available to the runtime environment
+
+!!! warning "System dependencies are required"
+    Even after installing the Python package, connection still depends on external ODBC or native Tibero client libraries being present and loadable.
+
+## Installation and backend decision flow
+
+```mermaid
+flowchart TD
+    A[Install pytibero] --> B{Which backend?}
+    B -->|pyodbc| C[Install pyodbc]
+    C --> D[Install/register Tibero ODBC driver]
+    D --> E[Use DSN or driver + host/port]
+    B -->|tbcli| F[Install Tibero native client]
+    F --> G[Set tbcli_library or library path]
+    G --> H[Connect with backend='tbcli']
+```
 
 ## Connection styles
 
@@ -45,6 +65,9 @@ import pytibero
 conn = pytibero.connect(dsn="TIBERO_TEST", user="tibero", password="tmax")
 ```
 
+!!! tip "DSN mode"
+    DSN mode delegates endpoint details to your ODBC manager configuration.
+
 ### Native tbCLI backend
 
 ```python
@@ -62,6 +85,9 @@ conn = pytibero.connect(
 Use the `tbcli` backend when the Tibero native client library is installed on
 the host. If `tbcli_library` is omitted, `pytibero` will try to discover
 `libtbcli.so` automatically.
+
+!!! warning "tbcli runtime loading"
+    If auto-discovery fails, provide an explicit absolute path via `tbcli_library`.
 
 ### Advanced options
 
@@ -82,3 +108,6 @@ Common `pyodbc.connect(...)` kwargs such as `readonly`, `ansi`, `timeout`,
 `attrs_before`, and `unicode_results` are passed through as native connection
 arguments. Other extra keyword arguments are appended to the ODBC connection
 string.
+
+!!! info "Keyword routing"
+    Refer to the [Connection Guide](connection.md) for a complete mapping of kwargs routed to native connect arguments versus ODBC string attributes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,103 @@
+# Quick Start
+
+Connect to Tibero in 5 minutes using `pytibero`.
+
+!!! info "Prerequisites"
+    - A reachable Tibero server
+    - Python 3.9+
+    - One backend path:
+      - `pyodbc` + a Tibero ODBC driver, or
+      - Tibero native `tbcli` library for the `tbcli` backend
+
+!!! warning "Backend dependencies are external"
+    `pip install pytibero` installs the Python package, but system-level ODBC or native Tibero client libraries still must be installed and discoverable.
+
+## 1) Install
+
+```bash
+pip install pytibero
+```
+
+## 2) Pick a connection mode
+
+### Mode A: Direct driver + host/port (default `pyodbc` backend)
+
+```python
+import pytibero
+
+conn = pytibero.connect(
+    host="localhost",
+    port=8629,
+    database="test",
+    user="tibero",
+    password="tmax",
+    driver="Tibero 7 ODBC Driver",
+)
+```
+
+### Mode B: DSN (`pyodbc` backend)
+
+```python
+import pytibero
+
+conn = pytibero.connect(
+    dsn="TIBERO_TEST",
+    user="tibero",
+    password="tmax",
+)
+```
+
+### Mode C: Native `tbcli` backend
+
+```python
+import pytibero
+
+conn = pytibero.connect(
+    host="localhost",
+    port=8629,
+    database="test",
+    user="tibero",
+    password="tmax",
+    backend="tbcli",
+    tbcli_library="/opt/tibero7/client/lib/libtbcli.so",  # optional if discoverable
+)
+```
+
+## 3) Run a query
+
+```python
+import pytibero
+
+with pytibero.connect(
+    host="localhost",
+    port=8629,
+    database="test",
+    user="tibero",
+    password="tmax",
+) as conn:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM dual")
+        rows = cur.fetchall()
+        print(rows)
+```
+
+## Quickstart workflow
+
+```mermaid
+flowchart TD
+    A[Install pytibero] --> B{Choose backend}
+    B -->|pyodbc| C[Configure Tibero ODBC driver or DSN]
+    B -->|tbcli| D[Install or locate libtbcli]
+    C --> E[Call pytibero.connect]
+    D --> E
+    E --> F[Create cursor]
+    F --> G[Execute SQL]
+    G --> H[Fetch rows]
+    H --> I[Commit or rollback and close]
+```
+
+## Next steps
+
+- [Connection Guide](connection.md)
+- [API Reference](api.md)
+- [Error Handling](errors.md)

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,88 @@
+# Type Mapping
+
+`pytibero` exposes PEP 249 type objects and constructor helpers from `pytibero.types`.
+
+## PEP 249 type objects
+
+These are `DBAPIType` instances.
+
+| Type object | Internal code set | Typical meaning |
+|---|---|---|
+| `STRING` | `{1, 12, 13}` | Character/text-like SQL values |
+| `BINARY` | `{2, 14}` | Binary/blob-like SQL values |
+| `NUMBER` | `{3, 4, 5, 6, 7}` | Numeric SQL values |
+| `DATETIME` | `{8, 9, 10, 11}` | Date/time SQL values |
+| `ROWID` | `{15}` | Row identifier values |
+
+!!! note "Placeholder metadata codes"
+    Current integer code sets are package-defined placeholders documented in code comments and may evolve as transport metadata mapping gets refined.
+
+## Type constructors
+
+| Function | Input | Return |
+|---|---|---|
+| `Date(year, month, day)` | calendar components | `datetime.date` |
+| `Time(hour, minute, second)` | time components | `datetime.time` |
+| `Timestamp(year, month, day, hour, minute, second)` | datetime components | `datetime.datetime` |
+| `DateFromTicks(ticks)` | Unix timestamp | `datetime.date` |
+| `TimeFromTicks(ticks)` | Unix timestamp | `datetime.time` |
+| `TimestampFromTicks(ticks)` | Unix timestamp | `datetime.datetime` |
+| `Binary(value)` | `bytes \| bytearray \| str` | `bytes` |
+
+`Binary(...)` behavior:
+
+- `bytes` -> returned unchanged
+- `bytearray` -> converted with `bytes(...)`
+- `str` -> UTF-8 encoded bytes
+- other types -> `TypeError`
+
+## SQL type ↔ Python type mapping
+
+The tbcli transport uses SQL type codes to decode fetched values.
+
+| SQL family / code | Python result |
+|---|---|
+| Integer-like numeric codes (`NUMBER` set, `SQL_SMALLINT`, `SQL_INTEGER`, `SQL_BIGINT`) | `int` when parseable, otherwise `decimal.Decimal` |
+| Floating codes (`SQL_FLOAT`, `SQL_REAL`, `SQL_DOUBLE`) | `float` |
+| `SQL_TYPE_DATE` | `datetime.date` |
+| `SQL_TYPE_TIME` | `datetime.time` |
+| `SQL_TYPE_TIMESTAMP` | `datetime.datetime` |
+| Binary codes (`SQL_BINARY`, `SQL_VARBINARY`, `SQL_LONGVARBINARY`) | `bytes` |
+| `STRING` / `ROWID` families | `str` |
+
+## `DBAPIType` comparison semantics
+
+`DBAPIType.__eq__` supports:
+
+- comparing with `int` type codes (`STRING == 12`)
+- comparing with another `DBAPIType` (value-set equality)
+
+`__ne__` negates `__eq__` result.
+
+```python
+from pytibero import STRING, NUMBER
+
+assert STRING == 12
+assert NUMBER != 12
+```
+
+## Type resolution flow
+
+```mermaid
+flowchart TD
+    A[Raw SQL column type code] --> B{Binary family?}
+    B -->|yes| C[Return bytes]
+    B -->|no| D{Numeric family?}
+    D -->|integer-like| E[Try int, fallback decimal.Decimal]
+    D -->|float-like| F[Return float]
+    D -->|no| G{Datetime family?}
+    G -->|date| H[datetime.date]
+    G -->|time| I[datetime.time]
+    G -->|timestamp| J[datetime.datetime]
+    G -->|no| K[Return str]
+```
+
+!!! warning "Common type gotchas"
+    - `Binary("text")` encodes as UTF-8 bytes. If byte-level format matters, pass explicit `bytes`.
+    - Numeric text may become `decimal.Decimal` when integer parsing fails.
+    - DB-API type objects are not Python classes; they are comparison helpers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,10 +31,15 @@ nav:
   - Home: index.md
   - Getting Started:
       - Installation: installation.md
-      - Architecture: architecture.md
-  - Development:
-      - Testing: testing.md
-      - Agent Playbook: agent-playbook.md
+      - Quick Start: quickstart.md
+      - Connection Guide: connection.md
+  - Reference:
+      - API Reference: api.md
+      - Type Mapping: types.md
+      - Error Handling: errors.md
+  - Architecture: architecture.md
+  - Testing: testing.md
+  - FAQ: faq.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Add 6 new doc pages: **quickstart.md**, **connection.md**, **api.md**, **types.md**, **errors.md**, **faq.md**
- Connection guide covers all ConnectionConfig fields, pyodbc/tbcli backends, DSN vs driver modes
- API reference documents connect(), Connection, Cursor, types, and exceptions
- Type mapping with SQL-to-Python mapping table and Mermaid diagrams
- Error handling guide with PEP 249 exception hierarchy diagram
- Enhanced existing pages (index, installation, architecture) with Mermaid diagrams and admonitions
- Updated mkdocs.yml with full structured navigation